### PR TITLE
Add minus-one fragment layout and callbacks

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
@@ -1,0 +1,26 @@
+package org.fossify.home.fragments
+
+import android.content.Context
+import android.util.AttributeSet
+import org.fossify.home.activities.MainActivity
+import org.fossify.home.databinding.MinusOneScreenBinding
+import org.fossify.home.interfaces.MinusOneFragmentListener
+
+class MinusOneFragment(context: Context, attributeSet: AttributeSet) :
+    MyFragment<MinusOneScreenBinding>(context, attributeSet) {
+
+    var listener: MinusOneFragmentListener? = null
+
+    override fun setupFragment(activity: MainActivity) {
+        this.activity = activity
+        binding = MinusOneScreenBinding.bind(this)
+    }
+
+    fun refresh() {
+        listener?.onRefreshRequested()
+    }
+
+    fun hide() {
+        listener?.onHideRequested()
+    }
+}

--- a/app/src/main/kotlin/org/fossify/home/interfaces/MinusOneFragmentListener.kt
+++ b/app/src/main/kotlin/org/fossify/home/interfaces/MinusOneFragmentListener.kt
@@ -1,0 +1,6 @@
+package org.fossify.home.interfaces
+
+interface MinusOneFragmentListener {
+    fun onRefreshRequested()
+    fun onHideRequested()
+}

--- a/app/src/main/res/layout/minus_one_screen.xml
+++ b/app/src/main/res/layout/minus_one_screen.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.fossify.home.fragments.MinusOneFragment xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/minus_one_holder"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/minus_one_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</org.fossify.home.fragments.MinusOneFragment>


### PR DESCRIPTION
## Summary
- add minus_one_screen layout
- implement MinusOneFragment with listener callbacks for refresh/hide
- define MinusOneFragmentListener interface

## Testing
- `./gradlew test` (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba5f53f69c833386ab57da15a12d91