### PR TITLE
Add minus-one page support

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
@@ -63,6 +63,7 @@ import org.fossify.home.BuildConfig
 import org.fossify.home.R
 import org.fossify.home.databinding.ActivityMainBinding
 import org.fossify.home.databinding.AllAppsFragmentBinding
+import org.fossify.home.databinding.MinusOneFragmentBinding
 import org.fossify.home.databinding.WidgetsFragmentBinding
 import org.fossify.home.dialogs.RenameItemDialog
 import org.fossify.home.extensions.config
@@ -151,6 +152,10 @@ class MainActivity : SimpleActivity(), FlingListener {
             fragment.setupFragment(this)
             fragment.y = mScreenHeight.toFloat()
             fragment.beVisible()
+        }
+
+        MinusOneFragmentBinding.inflate(layoutInflater, binding.minusOneContainer, true).apply {
+            root.setupFragment(this@MainActivity)
         }
 
         handleIntentAction(intent)
@@ -275,6 +280,9 @@ class MainActivity : SimpleActivity(), FlingListener {
             hideFragment(binding.widgetsFragment)
         } else if (binding.homeScreenGrid.resizeFrame.isVisible) {
             binding.homeScreenGrid.root.hideResizeLines()
+        } else if (binding.homeScreenGrid.root.getCurrentPage() == -1) {
+            binding.homeScreenGrid.root.skipToPage(0)
+            updateMinusOneVisibility()
         } else {
             // this is a home launcher app, avoid glitching by pressing Back
             //super.onBackPressed()
@@ -419,6 +427,7 @@ class MainActivity : SimpleActivity(), FlingListener {
 
                     if (!mIgnoreXMoveEvents) {
                         binding.homeScreenGrid.root.finalizeSwipe()
+                        updateMinusOneVisibility()
                     }
                 }
 
@@ -479,6 +488,7 @@ class MainActivity : SimpleActivity(), FlingListener {
 
                 runOnUiThread {
                     binding.homeScreenGrid.root.skipToPage(page)
+                    updateMinusOneVisibility()
                 }
                 // delay showing the shortcut both to let the user see adding it in realtime and hackily avoid concurrent modification exception at HomeScreenGrid
                 Thread.sleep(2000)
@@ -490,6 +500,10 @@ class MainActivity : SimpleActivity(), FlingListener {
                 }
             }
         }
+    }
+
+    private fun updateMinusOneVisibility() {
+        binding.minusOneContainer.isVisible = binding.homeScreenGrid.root.getCurrentPage() == -1
     }
 
     private fun findFirstEmptyCell(): Pair<Int, Rect> {

--- a/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
@@ -1,0 +1,17 @@
+package org.fossify.home.fragments
+
+import android.content.Context
+import android.util.AttributeSet
+import org.fossify.home.activities.MainActivity
+import org.fossify.home.databinding.MinusOneFragmentBinding
+
+class MinusOneFragment(
+    context: Context,
+    attributeSet: AttributeSet
+) : MyFragment<MinusOneFragmentBinding>(context, attributeSet) {
+    override fun setupFragment(activity: MainActivity) {
+        this.activity = activity
+        this.binding = MinusOneFragmentBinding.bind(this)
+    }
+}
+

--- a/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
@@ -1799,6 +1799,8 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) :
 
     fun getCurrentIconSize(): Int = iconSize
 
+    fun getCurrentPage(): Int = pager.getCurrentPage()
+
 
     fun setSwipeMovement(diffX: Float) {
         if (draggedItem == null) {
@@ -2259,7 +2261,7 @@ private class AnimatedGridPager(
             return
         }
 
-        if (currentPage < getMaxPage() && diffX > 0f || currentPage > 0 && diffX < 0f) {
+        if (currentPage < getMaxPage() && diffX > 0f || currentPage > -1 && diffX < 0f) {
             pageChangeSwipedPercentage = (-diffX / getWidth().toFloat()).coerceIn(-1f, 1f)
             pageChangeStarted()
             redrawGrid()
@@ -2322,7 +2324,7 @@ private class AnimatedGridPager(
     }
 
     fun prevPage(redraw: Boolean = false): Boolean {
-        if (currentPage > 0 && pageChangeEnabled) {
+        if (currentPage > -1 && pageChangeEnabled) {
             lastPage = currentPage
             currentPage--
             handlePageChange(redraw)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,6 +8,12 @@
         android:id="@+id/home_screen_grid"
         layout="@layout/home_screen_grid" />
 
+    <FrameLayout
+        android:id="@+id/minus_one_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
     <include
         android:id="@+id/all_apps_fragment"
         layout="@layout/all_apps_fragment"

--- a/app/src/main/res/layout/minus_one_fragment.xml
+++ b/app/src/main/res/layout/minus_one_fragment.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.fossify.home.fragments.MinusOneFragment xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/minus_one_holder"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />


### PR DESCRIPTION
## Summary
- Inflate and wire up a new MinusOneFragment to a dedicated container on the home screen
- Allow swiping from the first page to a new minus-one page and handle its visibility
- Ensure back navigation returns from minus-one to the main page

## Testing
- ⚠️ `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f550a6c83339bf293a2458d5ef9