### PR TITLE
Add minus one screen integration

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
@@ -1806,6 +1806,10 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) :
         return pager.skipToPage(targetPage)
     }
 
+    fun getCurrentPage(): Int = pager.getCurrentPage()
+
+    fun getMinPage(): Int = pager.getMinPage()
+
     fun getCurrentIconSize(): Int = iconSize
 
 


### PR DESCRIPTION
## Summary
- expose current and minimum pages from home screen grid
- integrate minus-one screen with MainActivity and implement listener hooks

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew detekt` *(fails: could not resolve detekt-cli dependencies)*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba68bc6e1083339f103e16c0ea1955