### PR TITLE
Add custom minus one screen

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
@@ -1,0 +1,36 @@
+package org.fossify.home.fragments
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import org.fossify.home.activities.MainActivity
+import org.fossify.home.databinding.MinusOneFragmentBinding
+
+class MinusOneFragment(
+    context: Context,
+    attributeSet: AttributeSet
+) : MyFragment<MinusOneFragmentBinding>(context, attributeSet) {
+
+    private var touchDownX = -1
+    private val moveGestureThreshold = context.resources.getDimensionPixelSize(org.fossify.home.R.dimen.move_gesture_threshold)
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun setupFragment(activity: MainActivity) {
+        this.activity = activity
+        binding = MinusOneFragmentBinding.bind(this)
+
+        setOnTouchListener { _, event ->
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> touchDownX = event.x.toInt()
+                MotionEvent.ACTION_UP -> {
+                    val diffX = event.x - touchDownX
+                    if (diffX > moveGestureThreshold) {
+                        activity.hideMinusOneFragment()
+                    }
+                }
+            }
+            true
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,6 +9,11 @@
         layout="@layout/home_screen_grid" />
 
     <include
+        android:id="@+id/minus_one_fragment"
+        layout="@layout/minus_one_fragment"
+        android:visibility="gone" />
+
+    <include
         android:id="@+id/all_apps_fragment"
         layout="@layout/all_apps_fragment"
         android:visibility="gone" />

--- a/app/src/main/res/layout/minus_one_fragment.xml
+++ b/app/src/main/res/layout/minus_one_fragment.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.fossify.home.fragments.MinusOneFragment xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/minus_one_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white">
+
+    <TextView
+        android:id="@+id/minus_one_placeholder"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="@string/minus_one_placeholder" />
+
+</org.fossify.home.fragments.MinusOneFragment>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="double_tap_to_lock">Double tap to lock screen</string>
     <string name="lock_device_admin_hint">To enable the double tap to lock screen feature, you need to grant admin permission. Note that the app cannot be uninstalled until this permission is removed.</string>
     <string name="lock_device_admin_warning">Deactivating admin permission will disable the double tap to lock screen feature.</string>
+    <string name="minus_one_placeholder">Minus one screen</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/FossifyOrg/Commons/tree/master/commons/src/main/res


### PR DESCRIPTION
## Summary
- add minus-one screen fragment accessible from left swipe
- block app drawer when minus-one screen is open
- placeholder layout and string for custom content
- allow dismissing minus-one screen with right swipe

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbaf3ca2cc83338252e80528da079a