### PR TITLE
Fix minus one screen swipe and expose current page

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
@@ -430,7 +430,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                     }
 
                     if (!mIgnoreXMoveEvents) {
-                        if (!isMinusOneFragmentExpanded() && !isAllAppsFragmentExpanded() && !isWidgetsFragmentExpanded() && binding.homeScreenGrid.root.getCurrentPage() == 0 && diffXUp < -mMoveGestureThreshold) {
+                        if (!isMinusOneFragmentExpanded() && !isAllAppsFragmentExpanded() && !isWidgetsFragmentExpanded() && binding.homeScreenGrid.root.getCurrentPage() == 0 && diffXUp > mMoveGestureThreshold) {
                             showMinusOneFragment()
                         } else {
                             binding.homeScreenGrid.root.finalizeSwipe()

--- a/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/org/fossify/home/views/HomeScreenGrid.kt
@@ -1797,6 +1797,8 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) :
         return pager.skipToPage(targetPage)
     }
 
+    fun getCurrentPage(): Int = pager.getCurrentPage()
+
     fun getCurrentIconSize(): Int = iconSize
 
 


### PR DESCRIPTION
## Summary
- Expose current home screen page from `HomeScreenGrid` so activities can query it
- Show the -1 screen only on left swipes from the first page

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbe6a1d1c8333a2130beb457a0186