### PR TITLE
Fix minus-one screen swipe gesture

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
@@ -430,7 +430,13 @@ class MainActivity : SimpleActivity(), FlingListener {
                     }
 
                     if (!mIgnoreXMoveEvents) {
-                        if (!isMinusOneFragmentExpanded() && !isAllAppsFragmentExpanded() && !isWidgetsFragmentExpanded() && binding.homeScreenGrid.root.getCurrentPage() == 0 && diffXUp > mMoveGestureThreshold) {
+                        if (
+                            !isMinusOneFragmentExpanded() &&
+                            !isAllAppsFragmentExpanded() &&
+                            !isWidgetsFragmentExpanded() &&
+                            binding.homeScreenGrid.root.getCurrentPage() == 0 &&
+                            diffXUp < -mScreenWidth / 2f
+                        ) {
                             showMinusOneFragment()
                         } else {
                             binding.homeScreenGrid.root.finalizeSwipe()


### PR DESCRIPTION
## Summary
- Fix swipe detection for opening the custom "minus one" screen by using a right-swipe equal to half the screen width

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc1126f4483339f7a5624aa17381a