### PR TITLE
Fix minus-one screen slide direction

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
@@ -149,7 +149,7 @@ class MainActivity : SimpleActivity(), FlingListener {
 
         (binding.minusOneFragment.root as MyFragment<*>).apply {
             setupFragment(this@MainActivity)
-            x = mScreenWidth.toFloat()
+            x = -mScreenWidth.toFloat()
             beVisible()
         }
 
@@ -398,7 +398,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                         mIgnoreYMoveEvents = true
 
                         if (isMinusOneFragmentExpanded()) {
-                            if (diffX < 0f) {
+                            if (diffX > 0f) {
                                 hideMinusOneFragment()
                                 mIgnoreXMoveEvents = true
                             }
@@ -406,7 +406,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                             !isAllAppsFragmentExpanded() &&
                             !isWidgetsFragmentExpanded() &&
                             binding.homeScreenGrid.root.getCurrentPage() == 0 &&
-                            diffX > 0f
+                            diffX < 0f
                         ) {
                             showMinusOneFragment()
                             mIgnoreXMoveEvents = true
@@ -670,7 +670,7 @@ class MainActivity : SimpleActivity(), FlingListener {
             return
         }
         binding.homeScreenGrid.root.beVisible()
-        ObjectAnimator.ofFloat(binding.minusOneFragment.root, "x", mScreenWidth.toFloat()).apply {
+        ObjectAnimator.ofFloat(binding.minusOneFragment.root, "x", -mScreenWidth.toFloat()).apply {
             duration = ANIMATION_DURATION
             interpolator = DecelerateInterpolator()
             start()

--- a/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
@@ -25,7 +25,7 @@ class MinusOneFragment(
                 MotionEvent.ACTION_DOWN -> touchDownX = event.x.toInt()
                 MotionEvent.ACTION_UP -> {
                     val diffX = event.x - touchDownX
-                    if (diffX < -moveGestureThreshold) {
+                    if (diffX > moveGestureThreshold) {
                         activity.hideMinusOneFragment()
                     }
                 }


### PR DESCRIPTION
## Summary
- Make minus-one screen originate from left edge
- Adjust gestures to match new left-side placement

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew detekt` *(fails: Could not resolve detekt-cli due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd07522d08333981d5fa581373020