### PR TITLE
Fix minus-one screen swipe direction

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
@@ -398,7 +398,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                         mIgnoreYMoveEvents = true
 
                         if (isMinusOneFragmentExpanded()) {
-                            if (diffX > 0f) {
+                            if (diffX < 0f) {
                                 hideMinusOneFragment()
                                 mIgnoreXMoveEvents = true
                             }
@@ -406,7 +406,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                             !isAllAppsFragmentExpanded() &&
                             !isWidgetsFragmentExpanded() &&
                             binding.homeScreenGrid.root.getCurrentPage() == 0 &&
-                            diffX < 0f
+                            diffX > 0f
                         ) {
                             showMinusOneFragment()
                             mIgnoreXMoveEvents = true

--- a/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
@@ -25,7 +25,7 @@ class MinusOneFragment(
                 MotionEvent.ACTION_DOWN -> touchDownX = event.x.toInt()
                 MotionEvent.ACTION_UP -> {
                     val diffX = event.x - touchDownX
-                    if (diffX > moveGestureThreshold) {
+                    if (diffX < -moveGestureThreshold) {
                         activity.hideMinusOneFragment()
                     }
                 }


### PR DESCRIPTION
## Summary
- fix minus-one fragment swipe gestures so right swipe opens the screen and left swipe closes it

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd28f8084833382a4d9c2e681f448