### PR TITLE
Fix minus-one screen swipe behavior

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
@@ -400,7 +400,6 @@ class MainActivity : SimpleActivity(), FlingListener {
                         if (isMinusOneFragmentExpanded()) {
                             if (diffX < 0f) {
                                 hideMinusOneFragment()
-                                mIgnoreXMoveEvents = true
                             }
                         } else if (
                             !isAllAppsFragmentExpanded() &&
@@ -409,7 +408,6 @@ class MainActivity : SimpleActivity(), FlingListener {
                             diffX > 0f
                         ) {
                             showMinusOneFragment()
-                            mIgnoreXMoveEvents = true
                         } else {
                             binding.homeScreenGrid.root.setSwipeMovement(-diffX)
                         }

--- a/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
+++ b/app/src/main/kotlin/org/fossify/home/fragments/MinusOneFragment.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
+import kotlin.math.min
 import org.fossify.home.activities.MainActivity
 import org.fossify.home.databinding.MinusOneFragmentBinding
 
@@ -12,8 +13,9 @@ class MinusOneFragment(
     attributeSet: AttributeSet
 ) : MyFragment<MinusOneFragmentBinding>(context, attributeSet) {
 
-    private var touchDownX = -1
+    private var touchDownX = -1f
     private val moveGestureThreshold = context.resources.getDimensionPixelSize(org.fossify.home.R.dimen.move_gesture_threshold)
+    private val screenWidth = resources.displayMetrics.widthPixels
 
     @SuppressLint("ClickableViewAccessibility")
     override fun setupFragment(activity: MainActivity) {
@@ -22,11 +24,18 @@ class MinusOneFragment(
 
         setOnTouchListener { _, event ->
             when (event.actionMasked) {
-                MotionEvent.ACTION_DOWN -> touchDownX = event.x.toInt()
-                MotionEvent.ACTION_UP -> {
-                    val diffX = event.x - touchDownX
+                MotionEvent.ACTION_DOWN -> touchDownX = event.rawX
+                MotionEvent.ACTION_MOVE -> {
+                    val diffX = event.rawX - touchDownX
+                    val newX = min(0f, diffX).coerceAtLeast(-screenWidth.toFloat())
+                    x = newX
+                }
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                    val diffX = event.rawX - touchDownX
                     if (diffX < -moveGestureThreshold) {
                         activity.hideMinusOneFragment()
+                    } else {
+                        activity.showMinusOneFragment()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Avoid ignoring horizontal gestures when showing or hiding the minus-one screen so it can react to direction changes
- Make the minus-one screen follow finger movement and finalize open/close on release

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew detekt` *(fails: 403 fetching detekt dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf6fd727c8333b33a1d99b5a2df0f