### PR TITLE
Fix minus one screen drag handling

### DIFF
--- a/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/home/activities/MainActivity.kt
@@ -400,14 +400,14 @@ class MainActivity : SimpleActivity(), FlingListener {
                                 a = max(0f, newY), b = mScreenHeight.toFloat()
                             )
                         }
-                    } else if (abs(diffX) > abs(diffY) && !mIgnoreXMoveEvents) {
+                    } else if ((abs(diffX) > abs(diffY) && !mIgnoreXMoveEvents) || mDraggingMinusOne) {
                         mIgnoreYMoveEvents = true
 
                         if (
                             !isAllAppsFragmentExpanded() &&
                             !isWidgetsFragmentExpanded() &&
                             binding.homeScreenGrid.root.getCurrentPage() == 0 &&
-                            (diffX > 0f || binding.minusOneFragment.root.x > -mScreenWidth)
+                            (diffX > 0f || binding.minusOneFragment.root.x > -mScreenWidth || mDraggingMinusOne)
                         ) {
                             val adjustedDiffX = max(0f, diffX.toFloat())
                             val newX = (-mScreenWidth + adjustedDiffX).coerceIn(-mScreenWidth.toFloat(), 0f)


### PR DESCRIPTION
## Summary
- ensure minus-one screen follows finger when being revealed by swiping from the home screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0eedcb988333931d745b4d7a2fc8